### PR TITLE
Support multiple lines of Label Text.

### DIFF
--- a/CaseBuilderLib_Label.scad
+++ b/CaseBuilderLib_Label.scad
@@ -25,38 +25,82 @@
 //# Version History:                                                            #
 //#   July 1, 2020                                                              #
 //#      - Initial release                                                      #
-//#                                                                             #
+//#   February 16, 2025                                                         #
+//#      - Supports multiple lines of text
 //###############################################################################
 
 include <CaseBuilderLib_Common.scad>
 
+//Common calculations for label positioning
+function getBaseZ(pSet) = 
+    let(
+        idimZ = pSet[idxIdimZ],
+        wallW = pSet[idxWallW]
+    )
+    wallW + idimZ/2;
+
+//Sum an array - replacement for missing OpenSCAD sum function
+function sumArray(arr, i=0) = 
+    i >= len(arr) ? 0 : arr[i] + sumArray(arr, i+1);
+
+//Calculate gap between adjacent lines based on their font sizes
+function getLineGap(size1, size2, spacing=1.2) = 
+    (size1 + size2)/2 * spacing;
+
+//Calculate total offset for a given line by accumulating all previous gaps
+function getLineOffset(fontSizes, lineIndex, spacing=1.2) = 
+    let(
+        numLines = len(fontSizes),
+        halfHeight = lineIndex == 0 ? 0 :
+            [for(i = [0:lineIndex-1])
+                getLineGap(fontSizes[i], fontSizes[i+1], spacing)]
+    )
+    lineIndex == 0 ? 0 : sumArray(halfHeight);
+
+//Convert single text to single-element array
+function normalizeTextToArray(value) = 
+    is_string(value) ? [value] : value;
+
+//Convert single size to array matching text length
+function normalizeSizeToArray(size, textArray) = 
+    is_list(size) ? size :  // If it's already a list, return as is
+    [for(i = [0:len(textArray)-1]) size];  // Otherwise create array of same size
+
 //Flat label
 module flatLabel(pSet) {
-    //Short cuts
-    idimX  = pSet[idxIdimX];  //Inner X dimension
-    idimY  = pSet[idxIdimY];  //Inner Y dimension
-    idimZ  = pSet[idxIdimZ];  //Inner Z dimension
-    wallW  = pSet[idxWallW];  //Wall thickness
-    labT   = pSet[idxLabT];   //Label text
-    labS   = pSet[idxLabS];   //Label size
+    //Short cuts and normalization
+    labT   = normalizeTextToArray(pSet[idxLabT]);       //Label text array
+    labS   = normalizeSizeToArray(pSet[idxLabS], labT); //Label size array
+    baseZ  = getBaseZ(pSet);
     
-    //Label
-    translate([0,0,wallW+idimZ/2]) text(text=labT,size=labS,halign="center",valign="center");
+    numLines = len(labT);
+    totalHeight = getLineOffset(labS, numLines-1);
+    
+    for(i = [0:numLines-1]) {
+        offset = totalHeight/2 - getLineOffset(labS, i);
+        translate([0, offset, baseZ]) 
+            text(text=labT[i], size=labS[i], halign="center", valign="center");
+    }
 }
 
 //Engrave label into top shell
 module engraveLabel(pSet) {
-    //Short cuts
-    idimX  = pSet[idxIdimX];  //Inner X dimension
-    idimY  = pSet[idxIdimY];  //Inner Y dimension
-    idimZ  = pSet[idxIdimZ];  //Inner Z dimension
-    wallW  = pSet[idxWallW];  //Wall thickness
-    labT   = pSet[idxLabT];   //Label text
-    labS   = pSet[idxLabS];   //Label size
+    //Short cuts and normalization
+    labT   = normalizeTextToArray(pSet[idxLabT]);       //Label text array
+    labS   = normalizeSizeToArray(pSet[idxLabS], labT); //Label size array
+    baseZ  = getBaseZ(pSet) - 0.4;                      //Apply offset for engraving
     
-    //Engrave
+    numLines = len(labT);
+    totalHeight = getLineOffset(labS, numLines-1);
+    
     difference() {
         children();
-        translate([0,0,wallW-0.4+idimZ/2]) linear_extrude(0.8) text(text=labT,size=labS,halign="center",valign="center");
+        
+        for(i = [0:numLines-1]) {
+            offset = totalHeight/2 - getLineOffset(labS, i);
+            translate([0, offset, baseZ]) 
+                linear_extrude(0.8) 
+                text(text=labT[i], size=labS[i], halign="center", valign="center");
+        }
     }
 }


### PR DESCRIPTION
You can now create text across multiple lines. For example:

```
//Label text
LabT=["Line 1", "Line 2", "Version 1"];
//Label size
LabS=[8, 8, 4]; // [0:40]
```

It is backward-compatible with old code, so this works as before:
```
LabT="Label Text";
LabS=8; // [0:40]
```

If you specify an array of text but `LabS` is just a number .
```
//Label text
LabT=["Line 1", "Line 2", "Version 1"];
//Label size
LabS=8; // [0:40]
```
then it will render all lines of text with the same size.